### PR TITLE
Big lot of updates!

### DIFF
--- a/samples/gpio_01.yaml
+++ b/samples/gpio_01.yaml
@@ -4,11 +4,22 @@
 # designed to work with CATS Integration in JMRI.
 
 substitutions:
-  global_debounce: 100ms # Use this to stop circuits flapping between occupied and unoccupied. I found 100ms is a good threshold for this.
+  global_debounce: 500ms # Use this to stop circuits flapping between occupied and unoccupied. I found 100ms is a good threshold for this.
   # Each block has an MQTT topic (Which JMRI watches) and a name (which appears in the ESP Logs)
-  block_1_topic: "/trains/track/turnout/QTSEN-STA-UpYardApproach"
-  block_1_name: "Downhill Approach - Up"
+  block_1_topic: "trains/track/sensor/Kiama/Up XOver"
+  block_1_name: "Kiama/Up XOver"
   # if you create additional blocks, copy and paste these two above and name them as appropriate.
+
+esphome:
+  on_boot:
+    - priority: -50.0
+      then: # duplicate this code for the refreshall command required in cats during an unscheduled restart
+        - mqtt.publish:
+            topic: $block_1_topic
+            payload: !lambda |-
+              return id(block_1_sensor).state ? "ACTIVE" : "INACTIVE";
+            retain: false
+            qos: 2
 
 binary_sensor:
   - platform: gpio
@@ -18,18 +29,19 @@ binary_sensor:
       mode:
         input: true
     id: block_1_sensor # Rename this if you have different blocks (block_2, block_3, etc)
-    internal: true
     filters:
       - delayed_on_off: $global_debounce
     on_press:
       then:
         - logger.log:
-            format: "$block_1_name | OCCUPIED" # Rename this variable if you have different blocks ($block_2_name, $block_3_name, etc)
+            format: "$block_1_name | OCCUPIED"
             level: INFO
             tag: block_sensor
         - mqtt.publish:
             topic: $block_1_topic
-            payload: THROWN
+            payload: ACTIVE
+            retain: false
+            qos: 2
     on_release:
       then:
         - logger.log:
@@ -38,4 +50,6 @@ binary_sensor:
             tag: block_sensor
         - mqtt.publish:
             topic: $block_1_topic
-            payload: CLOSED
+            payload: INACTIVE
+            retain: false
+            qos: 2

--- a/samples/sample_board_config.yaml
+++ b/samples/sample_board_config.yaml
@@ -6,21 +6,40 @@
 esphome:
   name: sta-bd-01
 
+# Randomly delay the boot of the ESP from 3 to 10 seconds
+  on_boot:
+    - priority: 600
+      then:
+        - lambda: |-
+            int random_delay = random(3000, 10001);  // milliseconds
+            ESP_LOGI("main", "Delaying boot for %d milliseconds", random_delay);
+            int delay_step = 100; // 100 ms delay steps to feed the watchdog
+            for (int i = 0; i < random_delay / delay_step; i++) {
+              delay(delay_step);
+              // Feed the watchdog
+              App.feed_wdt();
+            }
+            // Handle the remainder of the delay
+            delay(random_delay % delay_step);
+            ESP_LOGI("main", "Boot delay completed, continuing initialization");
+
 # the type of board. If you bought the 38 pin one on my README, you don't need to change this.
 esp32:
   board: nodemcu-32s
 
 # We selectively enable/disable logging components here.
 logger:
-  level: DEBUG # The base level of logging. We need Debug for Servo calibration but then hide other chatty stuff by setting things to NONE.
+  level: DEBUG
   logs:
-    number: DEBUG # required to be at DEBUG when you are calibrating servos
-    block_sensors: INFO # This is a custom log to make it easier to interpret
-    # Everything else that would be on the board we disable in favour of custom logging.
+    number: NONE # required to be at DEBUG when you are calibrating servos
+    block_sensors: INFO
+    # upstream components we dont care about
     servo: NONE
+    ledc: DEBUG
     esp32.preferences: NONE
-    sensor: NONE
     binary_sensor: NONE
+    sensor: DEBUG
+    # service logging
 
 # This is where we import component-specific configuration. For each template you bring across and modify,
 # simply uncomment a line that matches the file you copied.
@@ -29,11 +48,8 @@ logger:
 
 packages:
   #gpio: !include sta-bd-01/gpio_01.yaml
-  #gpio_2: !include sta-bd-01/gpio_02.yaml
-  #signal_ber_44_6: !include lib/signal_ber_44_6.yaml
-  #servos_01:  !include lib/servos_01.yaml
-  #servo_calibrate: !include template/lib/servos_01_calibrate.yaml
-
+  #servos_01:  !include sta-bd-01/servos_01.yaml
+  #signals: !include kia-bd-01/wled_signal.yaml
 
 # Configure the connection to MQTT. JMRI also connects to this server, and this is
 # how your ESPHome nodes and JMRI will exchange messages.
@@ -41,6 +57,11 @@ mqtt:
   broker: !secret layout_mqtt_broker_ip # connect to the layout control MQTT Broker.
   id: mqtt_server
   discovery: false
+  on_message:
+    - topic: /trains/track/turnout/ADM/ResetESPs
+      payload: "THROWN"
+      then:
+        - button.press: reboot_esp
 
 # Over-The-Air (OTA) updates allow you to update config on your ESPs once they are registered on your
 # Dashboard. A very useful feature especially for things like Servo configuration which
@@ -55,3 +76,8 @@ wifi:
   ssid: !secret layout_wifi_ssid
   password: !secret layout_wifi_password
   power_save_mode: none
+
+button:
+  - platform: restart
+    id: reboot_esp
+    name: "ESP Restart"

--- a/samples/servos_01.yaml
+++ b/samples/servos_01.yaml
@@ -4,10 +4,12 @@
 substitutions:
   # Global variable. Update this if you feel the servos are throwing too quickly.
   turnout_speed: 10s
-  
+  i2c_sda_pin: 16
+  i2c_scl_pin: 17
+
   # per-servo vars - turnout 1. You will need to copy/paste these two lines,
   # update the names (eg. turnout_02, turnout_03) etc as you add more servos.
-  turnout_01_name: balloon_loop_xover 
+  turnout_01_name: balloon_loop_xover
   turnout_01_topic: "/trains/track/turnout/SWI/Staging/Balloon Loop" # This should match what you configure in CATS.
 
 
@@ -15,8 +17,8 @@ web_server:
 # WebUI Stuff. We need the webserver to make realtime updates to point motor endpoints.
 
 number:
-# each point has 4 'template' entries, one for normal/reverse and backoff/normal endpoints. these again should be copied, 
-# and the 'turnout_01' updated for 'turnout_02', 'turnout_03' etc. This code below is what you see in the web portal to update your 
+# each point has 4 'template' entries, one for normal/reverse and backoff/normal endpoints. these again should be copied,
+# and the 'turnout_01' updated for 'turnout_02', 'turnout_03' etc. This code below is what you see in the web portal to update your
 # servos in realtime, and save the values to the ESP.
   - platform: template
     name: ${turnout_01_name}_servo_endpoint_normal
@@ -78,26 +80,10 @@ number:
             id: ${turnout_01_name}_servo
             level: !lambda 'return x / 100.0;'
 
-esphome:
-  on_boot:
-  
-    - priority: -200.0
-      then:
-        - logger.log:
-            format: 'Publishing Topics'
-            level: INFO
-            tag: init
-       # copy/paste the code below for each servo. This allows you to initialise each servo to normal whenever
-       # the ESP boots, so your control system is in sync.
-        - mqtt.publish:
-            topic: ${turnout_01_topic}
-            payload: 'CLOSED'
-        - delay: 1s
-
 i2c:
   # change these pins depending on where you plug your PCA board into.
-  sda: 33
-  scl: 32
+  sda: ${i2c_sda_pin}
+  scl: ${i2c_scl_pin}
   scan: true
   id: bus_a
 
@@ -161,6 +147,8 @@ text_sensor:
             - mqtt.publish:
                 topic: "${turnout_01_topic}/State"
                 payload: "THROWN"
+                retain: false
+                qos: 2
       - if:
           condition:
             text_sensor.state:
@@ -191,3 +179,5 @@ text_sensor:
             - mqtt.publish:
                 topic: "${turnout_01_topic}/State"
                 payload: "CLOSED"
+                retain: false
+                qos: 2

--- a/samples/servos_01.yaml
+++ b/samples/servos_01.yaml
@@ -9,8 +9,8 @@ substitutions:
 
   # per-servo vars - turnout 1. You will need to copy/paste these two lines,
   # update the names (eg. turnout_02, turnout_03) etc as you add more servos.
-  turnout_01_name: balloon_loop_xover
-  turnout_01_topic: "/trains/track/turnout/SWI/Staging/Balloon Loop" # This should match what you configure in CATS.
+  turnout_01_name: up_loop
+  turnout_01_topic: trains/track/turnout/Kiama/Up Loop # This should match what you configure in CATS.
 
 
 web_server:

--- a/samples/wled_signal.yaml
+++ b/samples/wled_signal.yaml
@@ -1,0 +1,68 @@
+---
+# Using WLED to drive WS2812B-based signals.
+# You can see my implementation of these on my blog:
+# https://illawarraline.net/signals-for-the-illawarra-line/
+
+
+substitutions:
+  # Set the pins you wish to use to communicate over serial to WLED.
+  signal_uart_pin_rx: 3
+  signal_uart_pin_tx: 1
+  # each signal needs a name/topic. Unfortunately id doesn't support - so _ will have to do.
+  signal_01_name: "KIA_45_26"
+  signal_01_topic: "KIA-45.26"
+
+logger:
+  baud_rate: 0 # disable logging via UART. this is required if you're using a UART pin reserved for esphome serial logging.
+
+uart: # Serial bus for the communication with WLED
+  - id: signal_uart
+    tx_pin: ${signal_uart_pin_tx}
+    rx_pin: ${signal_uart_pin_rx}
+    baud_rate: 115200
+
+text_sensor: # Text sensors per signal.
+  - platform: mqtt_subscribe
+    name: ${signal_01_name}
+    id: ${signal_01_name}
+    # integration with CATS masts in MQTT. This requires a custom signal mast, available here:
+    # https://github.com/aaron9589/cats-panel/tree/main/.jmri
+    topic: trains/track/signalmast/${signal_01_topic}
+    on_value:
+      - if: # example where there is a single condition to trigger a signal.
+          condition:
+              - text_sensor.state:
+                  id: ${signal_01_name}
+                  state: 'R292; Lit; Unheld' # Stop in the CATS mast table.
+          then:
+            - logger.log:
+                format: "sending a json payload to WLED"
+                level: INFO
+                tag: block_sensor
+            - uart.write:
+                id: signal_uart
+                # this is a JSON payload. more detail on this JSON payload available on the WLED website, and my
+                # implementation of it here: https://illawarraline.net/build-progress-05-24/
+                data: '{"seg":[{"id":4,"i":["0","ff0000","ff0000","0","0"],"frz":true,"on":true},{"id":5,"frz":true,"on":false}]}'
+
+      - if: # Additional If statements for other signal states.
+          condition:
+                - or:
+                # sometimes you have multiple conditions, here
+                # is an example of that. Helps to massage
+                # some of the signal aspects and push a bit beyond
+                # the CATS logic.
+                    - text_sensor.state:
+                        id: ${signal_01_name}
+                        state: 'R281; Lit; Unheld' # Proceed
+                    - text_sensor.state:
+                        id: ${signal_01_name}
+                        state: 'R282; Lit; Unheld' # Proceed
+          then:
+            - logger.log:
+                format: "sending a json payload to WLED"
+                level: INFO
+                tag: block_sensor
+            - uart.write:
+                id: signal_uart
+                data: '{"seg":[{"id":4,"i":["0","0","0","0","1fff87"],"frz":true,"on":true},{"id":5,"frz":false,"on":false}]}'


### PR DESCRIPTION
**GPIO Config**

- Updated `global_debounce` as a result of real-world use on my layout.
- Updated sample name and topics, based on my updated naming convention which is a little easier to read.
- Added a boot step to initialise and re-publish block states on start.

**General Board Config**
- Added a random boot delay on startup. This is designed to stop the devices all coming on at one and causing (albeit rare) issues. There are probably cleaner ways to do this, and I know this probably doesn't fit the ESPHome methodology, but it works.
- Added a reboot button which can be triggered off an MQTT topic or through the web interface of the board.

**Servo Config**
- Added some additional parameters for the I2C bus needed for the PCA9685 board.

**WLED Config**
- Added Sample for driving WLED signals.

**All components**
- Updated the MQTT topic to include a QOS of 2 (more reliable message delivery) and not retaining messages. Block detection is considered a state that is published when the layout power is initialised.

